### PR TITLE
feat: implement pv duplicate command

### DIFF
--- a/src/commands/duplicateCmd.ts
+++ b/src/commands/duplicateCmd.ts
@@ -1,0 +1,20 @@
+import { getDb } from '../db/schema.js';
+import chalk from 'chalk';
+import { duplicatePrompt } from '../db/queries.js';
+
+export async function duplicateCommand(idPrefix: string) {
+  const row = getDb().prepare('SELECT id FROM prompts WHERE id LIKE ?').get(`${idPrefix}%`) as { id: string } | undefined;
+
+  if (!row) {
+    console.log(chalk.red(`\u26A0 Prompt with ID starting with "${idPrefix}" not found.`));
+    return;
+  }
+
+  try {
+    const newId = duplicatePrompt(row.id);
+    console.log(`\n${chalk.green('\u2713')} Prompt duplicated successfully!`);
+    console.log(`New ID: ${chalk.cyan(newId.split('-')[0])}`);
+  } catch (err: any) {
+    console.log(chalk.red(`\u26A0 Failed to duplicate prompt: ${err.message}`));
+  }
+}

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -62,6 +62,17 @@ export function createPrompt(title: string, description: string, tags: string, i
   return promptId;
 }
 
+export function duplicatePrompt(promptId: string): string {
+  const prompt = getPrompt(promptId);
+  const version = getLatestVersion(promptId);
+  
+  if (!prompt || !version) {
+    throw new Error('Prompt or latest version not found.');
+  }
+
+  return createPrompt(`Copy of ${prompt.title}`, prompt.description, prompt.tags, version.text);
+}
+
 export function getAllPrompts(): PromptWithMeta[] {
   const db = getDb();
   return db.prepare(`

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ import { configCommand } from './commands/config.js';
 import { searchCommand } from './commands/search.js';
 import { importCommand } from './commands/importCmd.js';
 import { statsCommand } from './commands/statsCmd.js';
+import { duplicateCommand } from './commands/duplicateCmd.js';
 import { getProvider, isAiConfigured } from './utils/config.js';
 
 const program = new Command();
@@ -140,6 +141,11 @@ program
   .command('stats')
   .description('Show vault-wide analytics dashboard')
   .action(statsCommand);
+
+program
+  .command('duplicate <id>')
+  .description('Duplicate a prompt by ID')
+  .action(duplicateCommand);
 
 program.parse(process.argv);
 


### PR DESCRIPTION
Implements the \pv duplicate <id>\ command as requested. It creates a copy of the prompt with title prefixed with 'Copy of', copies only the text from the latest version, and prints the new shortened ID after creation.